### PR TITLE
Haptic for Android

### DIFF
--- a/Bomb/Assets/Plugins.meta
+++ b/Bomb/Assets/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 863d50d56f20c8f44b203806756cc392
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Bomb/Assets/Plugins/HapticAndroid.androidlib.meta
+++ b/Bomb/Assets/Plugins/HapticAndroid.androidlib.meta
@@ -1,0 +1,81 @@
+fileFormatVersion: 2
+guid: 6940ca451f71b4d0cac455cd7b0dabc8
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 0
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings:
+        AndroidSharedLibraryType: Executable
+        CPU: ARMv7
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Bomb/Assets/Plugins/HapticAndroid.androidlib/AndroidManifest.xml
+++ b/Bomb/Assets/Plugins/HapticAndroid.androidlib/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.GGamezebo.Bomb">
+
+    <!-- Essential Vibration Permission -->
+    <uses-permission android:name="android.permission.VIBRATE" />
+
+    <!-- For Android 12+ compatibility -->
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+
+    <!-- Optional: Prevent Doze mode blocking -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <application android:allowBackup="true">
+        <!-- Your library components (if any) -->
+    </application>
+
+</manifest>

--- a/Bomb/Assets/Plugins/HapticAndroid.androidlib/AndroidManifest.xml.bak
+++ b/Bomb/Assets/Plugins/HapticAndroid.androidlib/AndroidManifest.xml.bak
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.yourcompany.hapticlib">
+
+    <!-- Essential Vibration Permission -->
+    <uses-permission android:name="android.permission.VIBRATE" />
+
+    <!-- For Android 12+ compatibility -->
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+
+    <!-- Optional: Prevent Doze mode blocking -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <application android:allowBackup="true">
+        <!-- Your library components (if any) -->
+    </application>
+
+</manifest>

--- a/Bomb/Assets/Plugins/HapticiOS.mm
+++ b/Bomb/Assets/Plugins/HapticiOS.mm
@@ -1,0 +1,84 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+extern "C"
+{
+    void HapticFeedback(int type)
+    {
+        if (@available(iOS 10.0, *))
+        {
+            switch (type)
+            {
+                case 0: // Selection (iOS 10+)
+                    {
+                        UISelectionFeedbackGenerator* generator = [[UISelectionFeedbackGenerator alloc] init];
+                        [generator prepare] ;
+                        [generator selectionChanged] ;
+                        break;
+                    }
+                case 1: // Success (iOS 10+)
+                    {
+                        UINotificationFeedbackGenerator* generator = [[UINotificationFeedbackGenerator alloc] init];
+                        [generator prepare] ;
+                        [generator notificationOccurred:UINotificationFeedbackTypeSuccess];
+                        break;
+                    }
+                case 2: // Warning (iOS 10+)
+                    {
+                        UINotificationFeedbackGenerator* generator = [[UINotificationFeedbackGenerator alloc] init];
+                        [generator prepare] ;
+                        [generator notificationOccurred:UINotificationFeedbackTypeWarning] ;
+                        break;
+                    }
+                case 3: // Failure (iOS 10+)
+                    {
+                        UINotificationFeedbackGenerator* generator = [[UINotificationFeedbackGenerator alloc] init];
+                        [generator prepare] ;
+                        [generator notificationOccurred:UINotificationFeedbackTypeError] ;
+                        break;
+                    }
+                case 4: // LightImpact (iOS 10+)
+                    {
+                        UIImpactFeedbackGenerator* generator = [[UIImpactFeedbackGenerator alloc] initWithStyle: UIImpactFeedbackStyleLight];
+                        [generator prepare] ;
+                        [generator impactOccurred] ;
+                        break;
+                    }
+                case 5: // MediumImpact (iOS 10+)
+                    {
+                        UIImpactFeedbackGenerator* generator = [[UIImpactFeedbackGenerator alloc] initWithStyle: UIImpactFeedbackStyleMedium];
+                        [generator prepare] ;
+                        [generator impactOccurred] ;
+                        break;
+                    }
+                case 6: // HeavyImpact (iOS 10+)
+                    {
+                        UIImpactFeedbackGenerator* generator = [[UIImpactFeedbackGenerator alloc] initWithStyle: UIImpactFeedbackStyleHeavy];
+                        [generator prepare] ;
+                        [generator impactOccurred] ;
+                        break;
+                    }
+                case 7: // RigidImpact (iOS 13+)
+                    {
+                        if (@available(iOS 13.0, *))
+                        {
+                            UIImpactFeedbackGenerator* generator = [[UIImpactFeedbackGenerator alloc] initWithStyle: UIImpactFeedbackStyleRigid];
+                            [generator prepare] ;
+                            [generator impactOccurred] ;
+                        }
+                        break;
+                    }
+                case 8: // SoftImpact (iOS 13+)
+                    {
+                        if (@available(iOS 13.0, *))
+                        {
+                            UIImpactFeedbackGenerator* generator = [[UIImpactFeedbackGenerator alloc] initWithStyle: UIImpactFeedbackStyleSoft];
+                            [generator prepare] ;
+                            [generator impactOccurred] ;
+                        }
+                        break;
+                    }
+            }
+        }
+    }
+}

--- a/Bomb/Assets/Plugins/HapticiOS.mm.meta
+++ b/Bomb/Assets/Plugins/HapticiOS.mm.meta
@@ -1,0 +1,40 @@
+fileFormatVersion: 2
+guid: 73efa3a3f321c42e9b14b7ee63ce852e
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+AssetOrigin:
+  serializedVersion: 1
+  productId: 320664
+  packageName: Mobile Haptic Feedback
+  packageVersion: 1.0.1
+  assetPath: Assets/MOST_HapticFeedback/Plugins/iOS/MOST_HapticiOS.mm
+  uploadId: 764424

--- a/Bomb/Assets/Scenes/Game.unity
+++ b/Bomb/Assets/Scenes/Game.unity
@@ -395,7 +395,10 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5120844437825022175, guid: 504c61e0ee9671840a1295d4c4b99cbc, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1112863704}
   m_SourcePrefab: {fileID: 100100000, guid: 504c61e0ee9671840a1295d4c4b99cbc, type: 3}
 --- !u!114 &301042393 stripped
 MonoBehaviour:
@@ -1804,6 +1807,24 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 5120844437825022175, guid: 504c61e0ee9671840a1295d4c4b99cbc, type: 3}
   m_PrefabInstance: {fileID: 301042392}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1112863704
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1112863703}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 881cf4582b8e641c49b4e1d2de3a4c08, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomHapticPatternA:
+    IOS_HapticPattern: []
+    Android_HapticPattern: []
+  CustomHapticPatternB:
+    IOS_HapticPattern: []
+    Android_HapticPattern: []
 --- !u!1 &1118575176
 GameObject:
   m_ObjectHideFlags: 0

--- a/Bomb/Assets/Scenes/MainMenu.unity
+++ b/Bomb/Assets/Scenes/MainMenu.unity
@@ -1494,6 +1494,24 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 5120844437825022175, guid: 504c61e0ee9671840a1295d4c4b99cbc, type: 3}
   m_PrefabInstance: {fileID: 2323398408496604370}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1181238065
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1181238058}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 881cf4582b8e641c49b4e1d2de3a4c08, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomHapticPatternA:
+    IOS_HapticPattern: []
+    Android_HapticPattern: []
+  CustomHapticPatternB:
+    IOS_HapticPattern: []
+    Android_HapticPattern: []
 --- !u!1 &1301816928
 GameObject:
   m_ObjectHideFlags: 0
@@ -2154,7 +2172,10 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5120844437825022175, guid: 504c61e0ee9671840a1295d4c4b99cbc, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1181238065}
   m_SourcePrefab: {fileID: 100100000, guid: 504c61e0ee9671840a1295d4c4b99cbc, type: 3}
 --- !u!1001 &2777494925662028864
 PrefabInstance:

--- a/Bomb/Assets/Scripts/Lib/Unity/Haptic.meta
+++ b/Bomb/Assets/Scripts/Lib/Unity/Haptic.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 902b305f04684054487993eda33ca2dd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Bomb/Assets/Scripts/Lib/Unity/Haptic/HapticFeedback.cs
+++ b/Bomb/Assets/Scripts/Lib/Unity/Haptic/HapticFeedback.cs
@@ -1,0 +1,221 @@
+
+using UnityEngine;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Lib.Unity.Haptic
+{
+    public static class HapticFeedback
+    {
+        public enum HapticTypes
+        {
+            // These names are exactly the same as the objective c haptic feedback api (limited only to these feedbacks)
+            // so i have used these names on android as well...
+            // it's limited on ios but you can create unlimited custom patterns on android(check IOSDefaultHapticsToAndroidPatterns())
+
+            // Standart
+            Selection,    // case 0 // IOS 10+
+            Success,      // case 1 // IOS 10+
+            Warning,      // case 2 // IOS 10+
+            Failure,      // case 3 // IOS 10+
+            LightImpact,  // case 4 // IOS 10+
+            MediumImpact, // case 5 // IOS 10+
+            HeavyImpact,  // case 6 // IOS 10+
+            RigidImpact,  // case 7 // IOS 13+ <<
+            SoftImpact,   // case 8 // IOS 13+ <<
+
+            // for Bomb game
+            Play,
+            Alert,
+            Explosion,
+        }
+#if UNITY_ANDROID && !UNITY_EDITOR  // This function reverse iOS default haptics enum to android haptic patterns (Android only)
+        static void IOSDefaultHapticsToAndroidPatterns( 
+            HapticTypes type, out long[] pattern, out int[] amplitudes)
+        {
+            // using 'pattern' and 'amplitudes' create android custom haptic feedback
+            // pattern is the Timings for vibration pulses in milliseconds + delay betweem >>> Format [delay, vibrate, delay, vibrate, ...]
+            // amplitudes is the strength of the pulse >>> integer (0-255)
+            switch (type) 
+            {
+                case HapticTypes.Selection:
+                    pattern = new long[] { 0, 20 };
+                    amplitudes = new int[] { 0, 80 };
+                    break;
+                case HapticTypes.Success:
+                    pattern = new long[] { 0, 100, 50, 100 };
+                    amplitudes = new int[] { 0, 150, 0, 150 };
+                    break;
+                case HapticTypes.Warning:
+                    pattern = new long[] { 0, 200 };
+                    amplitudes = new int[] { 0, 200 };
+                    break;
+                case HapticTypes.Failure:
+                    pattern = new long[] { 0, 40, 40, 40 };
+                    amplitudes = new int[] { 0, 255, 0, 255 };
+                    break;
+                case HapticTypes.LightImpact:
+                    pattern = new long[] { 0, 50 };
+                    amplitudes = new int[] { 0, 100 };
+                    break;
+                case HapticTypes.MediumImpact:
+                    pattern = new long[] { 0, 100 };
+                    amplitudes = new int[] { 0, 180 };
+                    break;
+                case HapticTypes.HeavyImpact:
+                    pattern = new long[] { 0, 200 };
+                    amplitudes = new int[] { 0, 255 };
+                    break;
+                case HapticTypes.RigidImpact:
+                    pattern = new long[] { 0, 25 };
+                    amplitudes = new int[] { 0, 255 };
+                    break;
+                case HapticTypes.SoftImpact:
+                    pattern = new long[] { 0, 80 };
+                    amplitudes = new int[] { 0, 80 };
+                    break;
+
+                case HapticTypes.Play:
+                    pattern = new long[] { 0, 100, 50, 100 };
+                    amplitudes = new int[] { 0, 255, 0, 255 };
+                    break;
+                case HapticTypes.Alert:
+                    pattern = new long[] { 0, 100, 50, 100, 50, 1000 };
+                    amplitudes = new int[] { 0, 255, 0, 255, 0, 255 };
+                    break;
+                case HapticTypes.Explosion:
+                    pattern = new long[] { 0, 5000 };
+                    amplitudes = new int[] { 0, 255 };
+                    break;
+
+                default:
+                    pattern = new long[] { 0, 100 };
+                    amplitudes = new int[] { 0, 150 };
+                    break;
+            }
+        }
+#endif
+
+        static bool _hapticsEnabled = true;
+        static bool _initialized = false;
+        static AndroidJavaObject _androidVibrator;
+        static AndroidJavaClass _vibrationEffectClass;
+        static int _androidApiLevel;
+
+        // iOS Native Plugin Interface
+#if UNITY_IOS && !UNITY_EDITOR
+        [DllImport("__Internal")]
+        static extern void MOST_HapticFeedback(int type);
+#endif
+
+        [RuntimeInitializeOnLoadMethod]
+        static void Initialize()
+        {
+#if UNITY_ANDROID && !UNITY_EDITOR
+            InitializeAndroid();
+#endif
+
+#if UNITY_IOS && !UNITY_EDITOR
+            Debug.Log("Initializing iOS haptics");
+#endif
+
+            _initialized = true;
+        }
+
+        public static void Generate(HapticTypes type)
+        {
+            if (!_hapticsEnabled || !_initialized) return;
+
+#if UNITY_IOS && !UNITY_EDITOR
+            GenerateIOS(type);
+#elif UNITY_ANDROID && !UNITY_EDITOR
+            IOSDefaultHapticsToAndroidPatterns(type, out long[] pattern, out int[] amp);
+            GenerateAndroid(pattern, amp);
+#endif
+        }
+
+#if UNITY_ANDROID && !UNITY_EDITOR
+        static void InitializeAndroid()
+        {
+            try
+            {
+                using (var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
+                using (var currentActivity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity"))
+                {
+                    _androidVibrator = currentActivity.Call<AndroidJavaObject>("getSystemService", "vibrator");
+                    _androidApiLevel = new AndroidJavaClass("android.os.Build$VERSION").GetStatic<int>("SDK_INT");
+                
+                    if (_androidApiLevel >= 26) // Oreo 8.0+
+                    {
+                        _vibrationEffectClass = new AndroidJavaClass("android.os.VibrationEffect");
+                    }
+                }
+                Debug.Log("Android haptics initialized. API Level: " + _androidApiLevel);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Android haptics initialization failed: " + e.Message);
+            }
+        }
+#endif
+
+#if UNITY_IOS && !UNITY_EDITOR
+        static void GenerateIOS(HapticTypes type)
+        {
+            try
+            {
+                HapticFeedback((int)type);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Failed to generate iOS haptic {type}: {e.Message}");
+            }
+        }
+#endif
+
+#if UNITY_ANDROID && !UNITY_EDITOR
+        static void GenerateAndroid(long[] pattern,int[] amplitudes)
+        {
+            if (_androidVibrator == null || !_androidVibrator.Call<bool>("hasVibrator")) return;
+            try
+            {
+                if (_androidApiLevel >= 26)
+                {
+                    var effect = _vibrationEffectClass.CallStatic<AndroidJavaObject>(
+                        "createWaveform", 
+                        pattern, 
+                        amplitudes, 
+                        -1); // No repeat
+                    _androidVibrator.Call("vibrate", effect);
+                }
+                else
+                {
+                    _androidVibrator.Call("vibrate", pattern, -1);
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Failed to generate Android haptic : {e.Message}");
+            }
+        }
+#endif
+
+        public static bool IsSupported()
+        {
+#if UNITY_IOS && !UNITY_EDITOR
+        return true; // All iPhones since iPhone 7 support haptics
+#elif UNITY_ANDROID && !UNITY_EDITOR
+        return _androidVibrator != null && _androidVibrator.Call<bool>("hasVibrator");
+#else
+            return false;
+#endif
+        }
+
+        public static bool HapticsEnabled
+        {
+            get => _hapticsEnabled;
+            set => _hapticsEnabled = value;
+        }
+    }
+}

--- a/Bomb/Assets/Scripts/Lib/Unity/Haptic/HapticFeedback.cs.meta
+++ b/Bomb/Assets/Scripts/Lib/Unity/Haptic/HapticFeedback.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fe59658dabe3ea242acda489f6f86fd7

--- a/Bomb/Assets/Scripts/Lib/Unity/Haptic/HapticsManager.cs
+++ b/Bomb/Assets/Scripts/Lib/Unity/Haptic/HapticsManager.cs
@@ -1,0 +1,53 @@
+using Common;
+using GameLogic;
+using System;
+using UnityEngine;
+
+namespace Lib.Unity.Haptic
+{
+    public class HapticsManager : MonoBehaviour
+    {
+        private EventListener _eventListener;
+
+        private void Start()
+        {
+            var globalContext = FindFirstObjectByType<GlobalContext>();
+            _eventListener = globalContext.MakeEventListener();
+            Subscribe();
+        }
+
+        private void OnDisable()
+        {
+            _eventListener.RemoveAllListeners();
+        }
+
+        private void Subscribe()
+        {
+            _eventListener.Add(Events.EvAlert, new Action(OnAlert));
+            _eventListener.Add(Events.EvGameStateChanged, new Action<GameState>(OnGameStateChanged));
+        }
+
+        private void OnAlert()
+        {
+            HapticFeedback.Generate(HapticFeedback.HapticTypes.Alert);
+        }
+
+        private void OnGameStateChanged(GameState state)
+        {
+            switch (state)
+            {
+                case GameState.Play:
+                    HapticFeedback.Generate(HapticFeedback.HapticTypes.Play);
+                    break;
+                case GameState.Explosion:
+                    HapticFeedback.Generate(HapticFeedback.HapticTypes.Explosion);
+                    break;
+            }
+        }
+
+        public void ToggleHaptics(bool enabled)
+        {
+            HapticFeedback.HapticsEnabled = enabled;
+        }
+    }
+}

--- a/Bomb/Assets/Scripts/Lib/Unity/Haptic/HapticsManager.cs.meta
+++ b/Bomb/Assets/Scripts/Lib/Unity/Haptic/HapticsManager.cs.meta
@@ -1,0 +1,18 @@
+fileFormatVersion: 2
+guid: 881cf4582b8e641c49b4e1d2de3a4c08
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+AssetOrigin:
+  serializedVersion: 1
+  productId: 320664
+  packageName: Mobile Haptic Feedback
+  packageVersion: 1.0.1
+  assetPath: Assets/Scripts/Haptic/HapticsExample.cs
+  uploadId: 764424

--- a/Bomb/ProjectSettings/ProjectSettings.asset
+++ b/Bomb/ProjectSettings/ProjectSettings.asset
@@ -167,7 +167,7 @@ PlayerSettings:
   androidMaxAspectRatio: 2.4
   androidMinAspectRatio: 1
   applicationIdentifier:
-    Android: com.DefaultCompany.com.unity.template.mobile2D
+    Android: com.GGamezebo.Bomb
     Lumin: com.DefaultCompany.com.unity.template.mobile2D
     Standalone: com.DefaultCompany.com.unity.template.mobile2D
     iPhone: com.DefaultCompany.com.unity.template.mobile2D


### PR DESCRIPTION
Описание коммита:
> Added haptic support for android.
> Added haptic for 3 events for now.
> 
> Haptic for iOS need to added. No iOS device for test.
> 
> Haptic patterns need to be tuned. It's just support.
> 
> Source solutions: Mobile Haptic Feedback by Solo in AssetStore 
> https://assetstore.unity.com/packages/tools/integration/mobile-haptic-feedback-320664#description

Также изменил package name на com.GGamezebo.Bomb - так как нужно было добавить плагином изменения в андроид манифест, ну и сразу изменил на более валидное. Если имя нужно будет всё-равно изменить в дальнейшем, то желательно не забыть изменить его и в плагине.